### PR TITLE
Add Environment Service Layer

### DIFF
--- a/src/services/environment_service.rs
+++ b/src/services/environment_service.rs
@@ -1,0 +1,55 @@
+use crate::models::pagination::Pagination;
+use crate::models::environment::{
+    Environment, EnvironmentCreatePayload, EnvironmentFilter, EnvironmentSortOrder,
+    EnvironmentUpdatePayload,
+};
+use crate::repositories::base::Repository;
+use crate::repositories::environment_repository::EnvironmentRepository;
+use crate::services::base::Service;
+use anyhow::Error;
+use async_trait::async_trait;
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct EnvironmentService {
+    pub repository: EnvironmentRepository,
+}
+
+impl EnvironmentService {
+    pub fn new(repo: EnvironmentRepository) -> Self {
+        Self { repository: repo }
+    }
+}
+
+#[async_trait]
+impl Service<Environment> for EnvironmentService {
+    type CreatePayload = EnvironmentCreatePayload;
+    type UpdatePayload = EnvironmentUpdatePayload;
+    type Filter = EnvironmentFilter;
+    type Sort = EnvironmentSortOrder;
+
+    async fn create(&self, item: Self::CreatePayload) -> Result<Environment, Error> {
+        self.repository.create(item).await
+    }
+
+    async fn read(&self, id: Uuid) -> Result<Option<Environment>, Error> {
+        self.repository.read(id).await
+    }
+
+    async fn update(&self, id: Uuid, update: Self::UpdatePayload) -> Result<Environment, Error> {
+        self.repository.update(id, update).await
+    }
+
+    async fn delete(&self, id: Uuid) -> Result<bool, Error> {
+        self.repository.delete(id).await
+    }
+
+    async fn find(
+        &self,
+        filter: Self::Filter,
+        sort: Option<Vec<Self::Sort>>,
+        pagination: Option<Pagination>,
+    ) -> Result<Vec<Environment>, Error> {
+        self.repository.find(filter, sort, pagination).await
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -2,3 +2,4 @@ pub mod base;
 pub mod project_scope_service;
 pub mod project_service;
 pub mod service_account_service;
+pub mod environment_service;


### PR DESCRIPTION
This PR introduces the `EnvironmentService` to provide a service layer for environment management:

- **Service Implementation**:
  - Created `environment_service.rs` with `EnvironmentService` struct
  - Implements `Service<Environment>` trait with methods:
    - `create()`
    - `read()`
    - `update()`
    - `delete()`
    - `find()`
  - Delegates all operations directly to the underlying `EnvironmentRepository`
  - Provides a clean abstraction between routes and repository layer

- **Dependency Registration**:
  - Registered `environment_service` in `services/mod.rs`
  - Prepares for dependency injection and route configuration

This service layer ensures consistent business logic handling and provides a clear separation of concerns in the environment management feature.

Resolves #12 