### PR TITLE
Add Environment Routes and Integration Tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,11 @@
 use actix_web::{HttpServer, web};
+use sentinel_guard::repositories::environment_repository::EnvironmentRepository;
 use sentinel_guard::repositories::project_repository::ProjectRepository;
 use sentinel_guard::repositories::project_scope_repository::ProjectScopeRepository;
 use sentinel_guard::repositories::service_account_repository::ServiceAccountRepository;
+use sentinel_guard::routes::environment_route;
 use sentinel_guard::routes::service_account_route;
+use sentinel_guard::services::environment_service::EnvironmentService;
 use sentinel_guard::services::project_scope_service::ProjectScopeService;
 use sentinel_guard::services::project_service::ProjectService;
 use sentinel_guard::services::service_account_service::ServiceAccountService;
@@ -34,6 +37,11 @@ async fn main() -> Result<(), anyhow::Error> {
             project_scope_route::patch,
             project_scope_route::delete,
             project_scope_route::list,
+            environment_route::post,
+            environment_route::get,
+            environment_route::patch,
+            environment_route::delete,
+            environment_route::list,
         ),
         tags(
             (name = "SentinelGuard", description = "SentinelGuard API documentation.")
@@ -49,6 +57,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let service_account_service =
         ServiceAccountService::new(ServiceAccountRepository::new(pool.clone()));
     let project_scope_service = ProjectScopeService::new(ProjectScopeRepository::new(pool.clone()));
+    let environment_service = EnvironmentService::new(EnvironmentRepository::new(pool.clone()));
 
     let host = config.host;
     let port = config.port;
@@ -57,8 +66,11 @@ async fn main() -> Result<(), anyhow::Error> {
             .app_data(web::Data::new(project_service.clone()))
             .app_data(web::Data::new(service_account_service.clone()))
             .app_data(web::Data::new(project_scope_service.clone()))
+            .app_data(web::Data::new(environment_service.clone()))
             .configure(project_route::configure_routes)
             .configure(service_account_route::configure_routes)
+            .configure(project_scope_route::configure_routes)
+            .configure(environment_route::configure_routes)
             .service(
                 SwaggerUi::new("/docs/{_:.*}").url("/api-docs/openapi.json", ApiDoc::openapi()),
             )

--- a/src/routes/environment_route.rs
+++ b/src/routes/environment_route.rs
@@ -1,0 +1,183 @@
+use crate::models::pagination::Pagination;
+use crate::models::environment::{
+    EnvironmentCreatePayload, EnvironmentFilter, EnvironmentResponse, EnvironmentSortOrder,
+    EnvironmentSortableFields, EnvironmentUpdatePayload,
+};
+use crate::models::sort::SortOrder;
+use crate::services::base::Service;
+use crate::services::environment_service::EnvironmentService;
+use actix_web::{Error, HttpResponse, web};
+
+#[utoipa::path(
+    post,
+    path = "/environments",
+    tag = "Environments",
+    request_body = EnvironmentCreatePayload,
+    responses(
+        (status = 201, description = "Environment created", body = EnvironmentResponse),
+        (status = 400, description = "Invalid request", body = String),
+    ),
+)]
+pub async fn post(
+    service: web::Data<EnvironmentService>,
+    payload: web::Json<EnvironmentCreatePayload>,
+) -> Result<HttpResponse, Error> {
+    let environment = service
+        .create(payload.into_inner())
+        .await
+        .map_err(actix_web::error::ErrorBadRequest)?;
+    Ok(HttpResponse::Created().json(EnvironmentResponse::from(environment)))
+}
+
+#[utoipa::path(
+    get,
+    path = "/environments/{id}",
+    tag = "Environments",
+    responses(
+        (status = 200, description = "Environment found", body = EnvironmentResponse),
+        (status = 404, description = "Environment not found", body = String),
+    ),
+    params(
+        ("id" = String<uuid::Uuid>, Path, description = "Environment ID"),
+    ),
+)]
+pub async fn get(
+    service: web::Data<EnvironmentService>,
+    id: web::Path<uuid::Uuid>,
+) -> Result<HttpResponse, Error> {
+    let environment = service
+        .read(id.into_inner())
+        .await
+        .map_err(actix_web::error::ErrorNotFound)?;
+
+    Ok(HttpResponse::Ok().json(environment))
+}
+
+#[utoipa::path(
+    patch,
+    path = "/environments/{id}",
+    tag = "Environments",
+    responses(
+        (status = 200, description = "Environment updated", body = EnvironmentResponse),
+        (status = 400, description = "Invalid request", body = String),
+        (status = 404, description = "Environment not found", body = String),
+        (status = 409, description = "Environment already exists", body = String),
+        (status = 500, description = "Internal server error", body = String),
+    ),
+    params(
+        ("id" = String<uuid::Uuid>, Path, description = "Environment ID"),
+    ),
+)]
+pub async fn patch(
+    service: web::Data<EnvironmentService>,
+    id: web::Path<uuid::Uuid>,
+    payload: web::Json<EnvironmentUpdatePayload>,
+) -> Result<HttpResponse, Error> {
+    let environment = service.update(id.into_inner(), payload.into_inner()).await;
+
+    if environment.is_err() {
+        let error_message = environment.unwrap_err().to_string();
+        match error_message.as_str() {
+            "No changes to update" => return Err(actix_web::error::ErrorBadRequest(error_message)),
+            "Environment not found" => {
+                return Err(actix_web::error::ErrorNotFound(error_message));
+            }
+            "Project Id, name combination already exists" => {
+                return Err(actix_web::error::ErrorConflict(error_message));
+            }
+            _ => return Err(actix_web::error::ErrorInternalServerError(error_message)),
+        }
+    }
+
+    Ok(HttpResponse::Ok().json(EnvironmentResponse::from(environment.unwrap())))
+}
+
+#[utoipa::path(
+    delete,
+    path = "/environments/{id}",
+    tag = "Environments",
+    responses(
+        (status = 204, description = "Environment deleted", body = ()),
+        (status = 404, description = "Environment not found", body = String),
+    ),
+    params(
+        ("id" = String<uuid::Uuid>, Path, description = "Environment ID"),
+    )
+)]
+pub async fn delete(
+    service: web::Data<EnvironmentService>,
+    id: web::Path<uuid::Uuid>,
+) -> Result<HttpResponse, Error> {
+    let result = service.delete(id.into_inner()).await;
+
+    if result.is_err() {
+        let error_message = result.unwrap_err().to_string();
+        match error_message.as_str() {
+            "Environment not found" => {
+                return Err(actix_web::error::ErrorNotFound(error_message));
+            }
+            _ => return Err(actix_web::error::ErrorInternalServerError(error_message)),
+        }
+    }
+
+    Ok(HttpResponse::NoContent().finish())
+}
+
+#[utoipa::path(
+    get,
+    path = "/environments",
+    tag = "Environments",
+    responses(
+        (status = 200, description = "Environments found", body = Vec<EnvironmentResponse>),
+    ),
+    params(
+        ("project_id" = Option<String>, Query, description = "Filter environments by project ID"),
+        ("name" = Option<String>, Query, description = "Filter environments by name"),
+        ("description" = Option<String>, Query, description = "Filter environments by description"),
+        ("enabled" = Option<bool>, Query, description = "Filter environments by enabled status"),
+        ("offset" = Option<u32>, Query, description = "Offset for pagination"),
+        ("limit" = Option<u32>, Query, description = "Number of items per page"),
+    )
+)]
+pub async fn list(
+    service: web::Data<EnvironmentService>,
+    filter: web::Query<EnvironmentFilter>,
+    pagination: web::Query<Pagination>,
+) -> Result<HttpResponse, Error> {
+    let sort = vec![EnvironmentSortOrder::new(
+        EnvironmentSortableFields::Id,
+        SortOrder::Asc,
+    )];
+    let environments = service
+        .find(
+            filter.into_inner(),
+            Some(sort),
+            Some(pagination.into_inner()),
+        )
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    let responses: Vec<EnvironmentResponse> = environments
+        .into_iter()
+        .map(EnvironmentResponse::from)
+        .collect();
+
+    Ok(HttpResponse::Ok().json(responses))
+}
+
+pub fn configure_routes(config: &mut actix_web::web::ServiceConfig) {
+    config.service(
+        web::scope("/environments")
+            .service(
+                actix_web::web::resource("")
+                    .route(actix_web::web::post().to(post))
+                    .route(actix_web::web::get().to(list)),
+            )
+            .service(
+                actix_web::web::resource("/{id}")
+                    .route(actix_web::web::get().to(get))
+                    .route(actix_web::web::patch().to(patch))
+                    .route(actix_web::web::delete().to(delete)),
+            ),
+    );
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,3 +1,4 @@
 pub mod project_route;
 pub mod project_scope_route;
 pub mod service_account_route;
+pub mod environment_route;

--- a/tests/integration/routes/environment_route.rs
+++ b/tests/integration/routes/environment_route.rs
@@ -1,0 +1,325 @@
+use std::sync::Arc;
+
+use sentinel_guard::{
+    models::environment::{
+        EnvironmentCreatePayload, EnvironmentResponse, EnvironmentUpdatePayload,
+    },
+    repositories::environment_repository::EnvironmentRepository,
+    routes::environment_route,
+    services::environment_service::EnvironmentService,
+};
+use sqlx::PgPool;
+
+use crate::create_test_app;
+
+fn services(pool: PgPool) -> EnvironmentService {
+    EnvironmentService::new(EnvironmentRepository::new(Arc::new(pool)))
+}
+
+fn routes() -> fn(&mut actix_web::web::ServiceConfig) {
+    environment_route::configure_routes
+}
+
+#[sqlx::test(fixtures("../fixtures/projects.sql"))]
+async fn test_environment_route_create_environment_with_valid_data_succeeds(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+
+    let environment = EnvironmentCreatePayload {
+        name: "test-env".to_string(),
+        description: "Test Environment".to_string(),
+        enabled: true,
+        project_id: "123e4567-e89b-12d3-a456-426614174000".to_string(),
+    };
+
+    let response = actix_web::test::TestRequest::post()
+        .uri("/environments")
+        .set_json(&environment)
+        .send_request(&app)
+        .await;
+
+    assert!(response.status().is_success());
+}
+
+#[sqlx::test(fixtures("../fixtures/projects.sql", "../fixtures/environments.sql"))]
+async fn test_environment_route_create_environment_with_duplicate_project_id_name_fails(
+    pool: PgPool,
+) {
+    let app = create_test_app!(services(pool), routes());
+
+    let environment = EnvironmentCreatePayload {
+        name: "dev".to_string(),
+        description: "Development environment".to_string(),
+        enabled: true,
+        project_id: "123e4567-e89b-12d3-a456-426614174000".to_string(),
+    };
+
+    let response = actix_web::test::TestRequest::post()
+        .uri("/environments")
+        .set_json(&environment)
+        .send_request(&app)
+        .await;
+
+    assert!(response.status().is_client_error());
+    assert_eq!(response.status(), actix_web::http::StatusCode::BAD_REQUEST);
+}
+
+#[sqlx::test(fixtures("../fixtures/projects.sql", "../fixtures/environments.sql"))]
+async fn test_environment_route_read_environment_by_id_successful(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+
+    let response = actix_web::test::TestRequest::get()
+        .uri("/environments/00000000-0000-0000-0000-000000000001")
+        .send_request(&app)
+        .await;
+
+    assert!(response.status().is_success());
+}
+
+#[sqlx::test]
+async fn test_environment_route_read_environment_by_id_not_found(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+
+    let response = actix_web::test::TestRequest::get()
+        .uri("/environments/00000000-0000-0000-0000-000000000099")
+        .send_request(&app)
+        .await;
+
+    assert!(response.status().is_client_error());
+    assert_eq!(response.status(), actix_web::http::StatusCode::NOT_FOUND);
+}
+
+#[sqlx::test(fixtures("../fixtures/projects.sql", "../fixtures/environments.sql"))]
+async fn test_environment_route_patch_name_successful(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+
+    let payload = EnvironmentUpdatePayload {
+        name: Some("updated-name".to_string()),
+        description: None,
+        enabled: None,
+    };
+
+    let response = actix_web::test::TestRequest::patch()
+        .uri("/environments/00000000-0000-0000-0000-000000000001")
+        .set_json(&payload)
+        .send_request(&app)
+        .await;
+
+    assert!(response.status().is_success());
+}
+
+#[sqlx::test(fixtures("../fixtures/projects.sql", "../fixtures/environments.sql"))]
+async fn test_environment_route_patch_description_successful(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+
+    let payload = EnvironmentUpdatePayload {
+        name: None,
+        description: Some("Updated description".to_string()),
+        enabled: None,
+    };
+
+    let response = actix_web::test::TestRequest::patch()
+        .uri("/environments/00000000-0000-0000-0000-000000000001")
+        .set_json(&payload)
+        .send_request(&app)
+        .await;
+
+    assert!(response.status().is_success());
+}
+
+#[sqlx::test(fixtures("../fixtures/projects.sql", "../fixtures/environments.sql"))]
+async fn test_environment_route_patch_enabled_true_successful(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+
+    let payload = EnvironmentUpdatePayload {
+        name: None,
+        description: None,
+        enabled: Some(true),
+    };
+
+    let response = actix_web::test::TestRequest::patch()
+        .uri("/environments/00000000-0000-0000-0000-000000000002")
+        .set_json(&payload)
+        .send_request(&app)
+        .await;
+
+    assert!(response.status().is_success());
+}
+
+#[sqlx::test(fixtures("../fixtures/projects.sql", "../fixtures/environments.sql"))]
+async fn test_environment_route_patch_enabled_false_successful(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+
+    let payload = EnvironmentUpdatePayload {
+        name: None,
+        description: None,
+        enabled: Some(false),
+    };
+
+    let response = actix_web::test::TestRequest::patch()
+        .uri("/environments/00000000-0000-0000-0000-000000000001")
+        .set_json(&payload)
+        .send_request(&app)
+        .await;
+
+    assert!(response.status().is_success());
+}
+
+#[sqlx::test(fixtures("../fixtures/projects.sql", "../fixtures/environments.sql"))]
+async fn test_environment_route_patch_duplicate_project_id_name_fails(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+
+    let payload = EnvironmentUpdatePayload {
+        name: Some("staging".to_string()),
+        description: None,
+        enabled: None,
+    };
+
+    let response = actix_web::test::TestRequest::patch()
+        .uri("/environments/00000000-0000-0000-0000-000000000001")
+        .set_json(&payload)
+        .send_request(&app)
+        .await;
+
+    assert!(response.status().is_client_error());
+    assert_eq!(response.status(), actix_web::http::StatusCode::CONFLICT);
+}
+
+#[sqlx::test(fixtures("../fixtures/projects.sql", "../fixtures/environments.sql"))]
+async fn test_environment_route_delete_environment_successful(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+
+    let response = actix_web::test::TestRequest::delete()
+        .uri("/environments/00000000-0000-0000-0000-000000000001")
+        .send_request(&app)
+        .await;
+
+    assert_eq!(response.status(), actix_web::http::StatusCode::NO_CONTENT);
+}
+
+#[sqlx::test]
+async fn test_environment_route_delete_environment_not_found(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+
+    let response = actix_web::test::TestRequest::delete()
+        .uri("/environments/00000000-0000-0000-0000-000000000099")
+        .send_request(&app)
+        .await;
+
+    assert!(response.status().is_client_error());
+    assert_eq!(response.status(), actix_web::http::StatusCode::NOT_FOUND);
+}
+
+#[sqlx::test(fixtures("../fixtures/projects.sql", "../fixtures/environments.sql"))]
+async fn test_environment_route_list_environments_filter_by_project_id(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+
+    let response = actix_web::test::TestRequest::get()
+        .uri("/environments?project_id=123e4567-e89b-12d3-a456-426614174000")
+        .send_request(&app)
+        .await;
+
+    let environments: Vec<EnvironmentResponse> = actix_web::test::read_body_json(response).await;
+    assert!(!environments.is_empty());
+    assert!(environments
+        .iter()
+        .all(|e| e.project_id == "123e4567-e89b-12d3-a456-426614174000"));
+}
+
+#[sqlx::test(fixtures("../fixtures/projects.sql", "../fixtures/environments.sql"))]
+async fn test_environment_route_list_environments_filter_by_enabled_true(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+
+    let response = actix_web::test::TestRequest::get()
+        .uri("/environments?enabled=true")
+        .send_request(&app)
+        .await;
+
+    let environments: Vec<EnvironmentResponse> = actix_web::test::read_body_json(response).await;
+    assert!(!environments.is_empty());
+    assert!(environments.iter().all(|e| e.enabled));
+}
+
+#[sqlx::test(fixtures("../fixtures/projects.sql", "../fixtures/environments.sql"))]
+async fn test_environment_route_list_environments_filter_by_enabled_false(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+
+    let response = actix_web::test::TestRequest::get()
+        .uri("/environments?enabled=false")
+        .send_request(&app)
+        .await;
+
+    let environments: Vec<EnvironmentResponse> = actix_web::test::read_body_json(response).await;
+    assert!(!environments.is_empty());
+    assert!(environments.iter().all(|e| !e.enabled));
+}
+
+#[sqlx::test(fixtures("../fixtures/projects.sql", "../fixtures/environments.sql"))]
+async fn test_environment_route_list_environments_filter_by_name(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+
+    let response = actix_web::test::TestRequest::get()
+        .uri("/environments?name=dev")
+        .send_request(&app)
+        .await;
+
+    let environments: Vec<EnvironmentResponse> = actix_web::test::read_body_json(response).await;
+    assert!(!environments.is_empty());
+    assert!(environments.iter().all(|e| e.name == "dev"));
+}
+
+#[sqlx::test(fixtures("../fixtures/projects.sql", "../fixtures/environments.sql"))]
+async fn test_environment_route_list_environments_filter_by_description(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+
+    let response = actix_web::test::TestRequest::get()
+        .uri("/environments?description=Development")
+        .send_request(&app)
+        .await;
+
+    let environments: Vec<EnvironmentResponse> = actix_web::test::read_body_json(response).await;
+    assert!(!environments.is_empty());
+    assert!(environments
+        .iter()
+        .all(|e| e.description.contains("Development")));
+}
+
+#[sqlx::test(fixtures("../fixtures/projects.sql", "../fixtures/environments.sql"))]
+async fn test_environment_route_list_environments_limit_success(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+
+    let response = actix_web::test::TestRequest::get()
+        .uri("/environments?limit=1")
+        .send_request(&app)
+        .await;
+
+    let environments: Vec<EnvironmentResponse> = actix_web::test::read_body_json(response).await;
+    assert!(!environments.is_empty());
+    assert_eq!(environments.len(), 1);
+}
+
+#[sqlx::test(fixtures("../fixtures/projects.sql", "../fixtures/environments.sql"))]
+async fn test_environment_route_list_environments_offset_success(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+
+    // First request - get first item
+    let first_response = actix_web::test::TestRequest::get()
+        .uri("/environments?limit=1")
+        .send_request(&app)
+        .await;
+
+    // Second request - get second item using offset
+    let second_response = actix_web::test::TestRequest::get()
+        .uri("/environments?offset=1&limit=1")
+        .send_request(&app)
+        .await;
+
+    let first_env: Vec<EnvironmentResponse> = actix_web::test::read_body_json(first_response).await;
+    let second_env: Vec<EnvironmentResponse> = actix_web::test::read_body_json(second_response).await;
+
+    assert_eq!(first_env.len(), 1);
+    assert_eq!(second_env.len(), 1);
+    assert_ne!(
+        first_env[0].id, second_env[0].id,
+        "Offset pagination failed - returned same record"
+    );
+}

--- a/tests/integration/routes/mod.rs
+++ b/tests/integration/routes/mod.rs
@@ -1,3 +1,4 @@
 pub mod project_route;
 pub mod project_scope_route;
 pub mod service_account_route;
+pub mod environment_route;


### PR DESCRIPTION
This PR completes the environment management feature by adding routes and comprehensive integration tests:

- **Route Implementation**:
  - Created `environment_route.rs` with full CRUD and list endpoints
  - Handlers for:
    - `POST /environments`: Create environment
    - `GET /environments/{id}`: Read specific environment
    - `PATCH /environments/{id}`: Update environment
    - `DELETE /environments/{id}`: Delete environment
    - `GET /environments`: List environments with advanced filtering

- **Integration Test Coverage**:
  - Create endpoint tests:
    - Successful creation
    - Handling duplicate environment creation
  
  - Read endpoint tests:
    - Successfully retrieve existing environment
    - Handle non-existent environment retrieval
  
  - Update (PATCH) endpoint tests:
    - Update name
    - Update description
    - Toggle enabled status
    - Prevent duplicate name updates
  
  - Delete endpoint tests:
    - Successfully delete existing environment
    - Handle deleting non-existent environment
  
  - List endpoint tests with filters:
    - Filter by project_id
    - Filter by name
    - Filter by description
    - Filter by enabled status (true/false)
    - Pagination support (limit, offset)

- **Main Application Configuration**:
  - Import `EnvironmentRepository`, `EnvironmentService`, and `environment_route`
  - Add environment routes to OpenAPI documentation
  - Instantiate `EnvironmentService`
  - Add `environment_service` to application data
  - Configure `environment_route::configure_routes`

This completes the environment management feature, providing a fully tested, documented, and integrated API for managing environments within the system.

Resolves #13 