### PR TITLE
Add Project Access and Project Access Scopes Services

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,13 @@
 use actix_web::{HttpServer, web};
 use sentinel_guard::repositories::environment_repository::EnvironmentRepository;
+use sentinel_guard::repositories::project_access_repository::ProjectAccessRepository;
 use sentinel_guard::repositories::project_repository::ProjectRepository;
 use sentinel_guard::repositories::project_scope_repository::ProjectScopeRepository;
 use sentinel_guard::repositories::service_account_repository::ServiceAccountRepository;
 use sentinel_guard::routes::environment_route;
 use sentinel_guard::routes::service_account_route;
 use sentinel_guard::services::environment_service::EnvironmentService;
+use sentinel_guard::services::project_access_service::ProjectAccessService;
 use sentinel_guard::services::project_scope_service::ProjectScopeService;
 use sentinel_guard::services::project_service::ProjectService;
 use sentinel_guard::services::service_account_service::ServiceAccountService;
@@ -58,6 +60,7 @@ async fn main() -> Result<(), anyhow::Error> {
         ServiceAccountService::new(ServiceAccountRepository::new(pool.clone()));
     let project_scope_service = ProjectScopeService::new(ProjectScopeRepository::new(pool.clone()));
     let environment_service = EnvironmentService::new(EnvironmentRepository::new(pool.clone()));
+    let project_access_service = ProjectAccessService::new(ProjectAccessRepository::new(pool.clone()));
 
     let host = config.host;
     let port = config.port;
@@ -67,6 +70,7 @@ async fn main() -> Result<(), anyhow::Error> {
             .app_data(web::Data::new(service_account_service.clone()))
             .app_data(web::Data::new(project_scope_service.clone()))
             .app_data(web::Data::new(environment_service.clone()))
+            .app_data(web::Data::new(project_access_service.clone()))
             .configure(project_route::configure_routes)
             .configure(service_account_route::configure_routes)
             .configure(project_scope_route::configure_routes)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,14 @@
 use actix_web::{HttpServer, web};
 use sentinel_guard::repositories::environment_repository::EnvironmentRepository;
 use sentinel_guard::repositories::project_access_repository::ProjectAccessRepository;
+use sentinel_guard::repositories::project_access_scopes_repository::ProjectAccessScopesRepository;
 use sentinel_guard::repositories::project_repository::ProjectRepository;
 use sentinel_guard::repositories::project_scope_repository::ProjectScopeRepository;
 use sentinel_guard::repositories::service_account_repository::ServiceAccountRepository;
 use sentinel_guard::routes::environment_route;
 use sentinel_guard::routes::service_account_route;
 use sentinel_guard::services::environment_service::EnvironmentService;
+use sentinel_guard::services::project_access_scopes_service::ProjectAccessScopesService;
 use sentinel_guard::services::project_access_service::ProjectAccessService;
 use sentinel_guard::services::project_scope_service::ProjectScopeService;
 use sentinel_guard::services::project_service::ProjectService;
@@ -61,6 +63,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let project_scope_service = ProjectScopeService::new(ProjectScopeRepository::new(pool.clone()));
     let environment_service = EnvironmentService::new(EnvironmentRepository::new(pool.clone()));
     let project_access_service = ProjectAccessService::new(ProjectAccessRepository::new(pool.clone()));
+    let project_access_scopes_service = ProjectAccessScopesService::new(ProjectAccessScopesRepository::new(pool.clone()));
 
     let host = config.host;
     let port = config.port;
@@ -71,6 +74,7 @@ async fn main() -> Result<(), anyhow::Error> {
             .app_data(web::Data::new(project_scope_service.clone()))
             .app_data(web::Data::new(environment_service.clone()))
             .app_data(web::Data::new(project_access_service.clone()))
+            .app_data(web::Data::new(project_access_scopes_service.clone()))
             .configure(project_route::configure_routes)
             .configure(service_account_route::configure_routes)
             .configure(project_scope_route::configure_routes)

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -3,3 +3,4 @@ pub mod environment_service;
 pub mod project_scope_service;
 pub mod project_service;
 pub mod service_account_service;
+pub mod project_access_service;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -4,3 +4,4 @@ pub mod project_scope_service;
 pub mod project_service;
 pub mod service_account_service;
 pub mod project_access_service;
+pub mod project_access_scopes_service;

--- a/src/services/project_access_scopes_service.rs
+++ b/src/services/project_access_scopes_service.rs
@@ -1,0 +1,55 @@
+use crate::models::pagination::Pagination;
+use crate::models::project_access_scopes::{
+    ProjectAccessScope, ProjectAccessScopeCreatePayload, ProjectAccessScopeFilter,
+    ProjectAccessScopeSortOrder, ProjectAccessScopeUpdatePayload,
+};
+use crate::repositories::base::Repository;
+use crate::repositories::project_access_scopes_repository::ProjectAccessScopesRepository;
+use crate::services::base::Service;
+use anyhow::Error;
+use async_trait::async_trait;
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct ProjectAccessScopesService {
+    pub repository: ProjectAccessScopesRepository,
+}
+
+impl ProjectAccessScopesService {
+    pub fn new(repo: ProjectAccessScopesRepository) -> Self {
+        Self { repository: repo }
+    }
+}
+
+#[async_trait]
+impl Service<ProjectAccessScope> for ProjectAccessScopesService {
+    type CreatePayload = ProjectAccessScopeCreatePayload;
+    type UpdatePayload = ProjectAccessScopeUpdatePayload;
+    type Filter = ProjectAccessScopeFilter;
+    type Sort = ProjectAccessScopeSortOrder;
+
+    async fn create(&self, item: Self::CreatePayload) -> Result<ProjectAccessScope, Error> {
+        self.repository.create(item).await
+    }
+
+    async fn read(&self, id: Uuid) -> Result<Option<ProjectAccessScope>, Error> {
+        self.repository.read(id).await
+    }
+
+    async fn update(&self, id: Uuid, update: Self::UpdatePayload) -> Result<ProjectAccessScope, Error> {
+        self.repository.update(id, update).await
+    }
+
+    async fn delete(&self, id: Uuid) -> Result<bool, Error> {
+        self.repository.delete(id).await
+    }
+
+    async fn find(
+        &self,
+        filter: Self::Filter,
+        sort: Option<Vec<Self::Sort>>,
+        pagination: Option<Pagination>,
+    ) -> Result<Vec<ProjectAccessScope>, Error> {
+        self.repository.find(filter, sort, pagination).await
+    }
+}

--- a/src/services/project_access_service.rs
+++ b/src/services/project_access_service.rs
@@ -1,0 +1,55 @@
+use crate::models::pagination::Pagination;
+use crate::models::project_access::{
+    ProjectAccess, ProjectAccessCreatePayload, ProjectAccessFilter, ProjectAccessSortOrder,
+    ProjectAccessUpdatePayload,
+};
+use crate::repositories::base::Repository;
+use crate::repositories::project_access_repository::ProjectAccessRepository;
+use crate::services::base::Service;
+use anyhow::Error;
+use async_trait::async_trait;
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct ProjectAccessService {
+    pub repository: ProjectAccessRepository,
+}
+
+impl ProjectAccessService {
+    pub fn new(repo: ProjectAccessRepository) -> Self {
+        Self { repository: repo }
+    }
+}
+
+#[async_trait]
+impl Service<ProjectAccess> for ProjectAccessService {
+    type CreatePayload = ProjectAccessCreatePayload;
+    type UpdatePayload = ProjectAccessUpdatePayload;
+    type Filter = ProjectAccessFilter;
+    type Sort = ProjectAccessSortOrder;
+
+    async fn create(&self, item: Self::CreatePayload) -> Result<ProjectAccess, Error> {
+        self.repository.create(item).await
+    }
+
+    async fn read(&self, id: Uuid) -> Result<Option<ProjectAccess>, Error> {
+        self.repository.read(id).await
+    }
+
+    async fn update(&self, id: Uuid, update: Self::UpdatePayload) -> Result<ProjectAccess, Error> {
+        self.repository.update(id, update).await
+    }
+
+    async fn delete(&self, id: Uuid) -> Result<bool, Error> {
+        self.repository.delete(id).await
+    }
+
+    async fn find(
+        &self,
+        filter: Self::Filter,
+        sort: Option<Vec<Self::Sort>>,
+        pagination: Option<Pagination>,
+    ) -> Result<Vec<ProjectAccess>, Error> {
+        self.repository.find(filter, sort, pagination).await
+    }
+}


### PR DESCRIPTION
This PR introduces service layers for managing Project Access and Project Access Scopes:

- **Project Access Service**:
  - Created `ProjectAccessService` to handle CRUD operations for project access records
  - Implements methods:
    - `create()`
    - `read()`
    - `update()`
    - `delete()`
    - `find()`
  - Delegates operations to `ProjectAccessRepository`
  - Registered in `services/mod.rs`
  - Integrated into main application configuration

- **Project Access Scopes Service**:
  - Created `ProjectAccessScopesService` to manage project access scope operations
  - Implements methods:
    - `create()`
    - `read()`
    - `update()`
    - `delete()`
    - `find()`
  - Delegates operations to `ProjectAccessScopesRepository`
  - Registered in `services/mod.rs`
  - Integrated into main application configuration

Key features:
- Provides a clean abstraction between routes and repository layer
- Ensures consistent business logic handling
- Prepares for dependency injection and route configuration

This implementation completes the service layer for project access management, following the established pattern of previous service implementations in the system.