### PR TITLE
Add Project Access and Project Access Scopes Routes with Comprehensive Testing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,10 @@ use sentinel_guard::services::project_access_service::ProjectAccessService;
 use sentinel_guard::services::project_scope_service::ProjectScopeService;
 use sentinel_guard::services::project_service::ProjectService;
 use sentinel_guard::services::service_account_service::ServiceAccountService;
-use sentinel_guard::{config::AppConfig, routes::project_route, routes::project_scope_route};
+use sentinel_guard::{
+    config::AppConfig, routes::project_access_route, routes::project_access_scopes_route,
+    routes::project_route, routes::project_scope_route,
+};
 use sqlx::postgres::PgPool;
 use std::{sync::Arc, time::Duration};
 use tokio::signal;
@@ -46,6 +49,16 @@ async fn main() -> Result<(), anyhow::Error> {
             environment_route::patch,
             environment_route::delete,
             environment_route::list,
+            project_access_route::post,
+            project_access_route::get,
+            project_access_route::patch,
+            project_access_route::delete,
+            project_access_route::list,
+            project_access_scopes_route::post,
+            project_access_scopes_route::get,
+            project_access_scopes_route::patch,
+            project_access_scopes_route::delete,
+            project_access_scopes_route::list,
         ),
         tags(
             (name = "SentinelGuard", description = "SentinelGuard API documentation.")
@@ -81,6 +94,8 @@ async fn main() -> Result<(), anyhow::Error> {
             .configure(service_account_route::configure_routes)
             .configure(project_scope_route::configure_routes)
             .configure(environment_route::configure_routes)
+            .configure(project_access_route::configure_routes)
+            .configure(project_access_scopes_route::configure_routes)
             .service(
                 SwaggerUi::new("/docs/{_:.*}").url("/api-docs/openapi.json", ApiDoc::openapi()),
             )

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,8 +62,10 @@ async fn main() -> Result<(), anyhow::Error> {
         ServiceAccountService::new(ServiceAccountRepository::new(pool.clone()));
     let project_scope_service = ProjectScopeService::new(ProjectScopeRepository::new(pool.clone()));
     let environment_service = EnvironmentService::new(EnvironmentRepository::new(pool.clone()));
-    let project_access_service = ProjectAccessService::new(ProjectAccessRepository::new(pool.clone()));
-    let project_access_scopes_service = ProjectAccessScopesService::new(ProjectAccessScopesRepository::new(pool.clone()));
+    let project_access_service =
+        ProjectAccessService::new(ProjectAccessRepository::new(pool.clone()));
+    let project_access_scopes_service =
+        ProjectAccessScopesService::new(ProjectAccessScopesRepository::new(pool.clone()));
 
     let host = config.host;
     let port = config.port;

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,4 +1,5 @@
 pub mod environment_route;
+pub mod project_access_route;
 pub mod project_route;
 pub mod project_scope_route;
 pub mod service_account_route;

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,5 +1,6 @@
 pub mod environment_route;
 pub mod project_access_route;
+pub mod project_access_scopes_route;
 pub mod project_route;
 pub mod project_scope_route;
 pub mod service_account_route;

--- a/src/routes/project_access_route.rs
+++ b/src/routes/project_access_route.rs
@@ -1,0 +1,143 @@
+use crate::models::pagination::Pagination;
+use crate::models::project_access::{
+    ProjectAccessFilter, ProjectAccessResponse, ProjectAccessSortOrder,
+    ProjectAccessSortableFields, ProjectAccessUpdatePayload,
+};
+use crate::models::sort::SortOrder;
+use crate::services::project_access_service::ProjectAccessService;
+use crate::{models::project_access::ProjectAccessCreatePayload, services::base::Service};
+use actix_web::{Error, HttpResponse, web};
+use uuid::Uuid;
+
+#[utoipa::path(
+    post,
+    path = "/projects/{project_id}/access",
+    tag = "Projects",
+    request_body = ProjectAccessCreatePayload,
+    responses(
+        (status = 201, description = "Project access created", body = ProjectAccessResponse),
+        (status = 400, description = "Invalid request", body = String),
+    ),
+)]
+pub async fn post(
+    service: web::Data<ProjectAccessService>,
+    payload: web::Json<ProjectAccessCreatePayload>,
+) -> Result<HttpResponse, Error> {
+    let project_access = service
+        .create(payload.into_inner())
+        .await
+        .map_err(actix_web::error::ErrorBadRequest)?;
+    Ok(HttpResponse::Created().json(project_access))
+}
+
+#[utoipa::path(
+    get,
+    path = "/projects/{project_id}/access/{id}",
+    tag = "Projects",
+    responses(
+        (status = 200, description = "Project access retrieved", body = ProjectAccessResponse), 
+        (status = 400, description = "Invalid request", body = String),
+    ),
+)]
+pub async fn get(
+    service: web::Data<ProjectAccessService>,
+    id: web::Path<Uuid>,
+) -> Result<HttpResponse, Error> {
+    let project_access = service
+        .read(id.into_inner())
+        .await
+        .map_err(actix_web::error::ErrorBadRequest)?;
+    Ok(HttpResponse::Ok().json(project_access))
+}
+
+#[utoipa::path(
+    patch,
+    path = "/projects/{project_id}/access/{id}",
+    tag = "Projects",
+    request_body = ProjectAccessUpdatePayload,
+    responses(
+        (status = 200, description = "Project access updated", body = ProjectAccessResponse),
+        (status = 400, description = "Invalid request", body = String),
+    ),
+)]
+pub async fn patch(
+    service: web::Data<ProjectAccessService>,
+    id: web::Path<Uuid>,
+    payload: web::Json<ProjectAccessUpdatePayload>,
+) -> Result<HttpResponse, Error> {
+    let project_access = service
+        .update(id.into_inner(), payload.into_inner())
+        .await
+        .map_err(actix_web::error::ErrorBadRequest)?;
+    Ok(HttpResponse::Ok().json(project_access))
+}
+
+#[utoipa::path(
+    delete,
+    path = "/projects/{project_id}/access/{id}",
+    tag = "Projects",
+    responses(
+        (status = 200, description = "Project access deleted", body = ProjectAccessResponse),
+        (status = 400, description = "Invalid request", body = String),
+    ),
+)]
+pub async fn delete(
+    service: web::Data<ProjectAccessService>,
+    id: web::Path<Uuid>,
+) -> Result<HttpResponse, Error> {
+    let project_access = service
+        .delete(id.into_inner())
+        .await
+        .map_err(actix_web::error::ErrorBadRequest)?;
+    Ok(HttpResponse::Ok().json(project_access))
+}
+
+#[utoipa::path(
+    get,
+    path = "/projects/{project_id}/access",
+    tag = "Projects",
+    responses(
+            (status = 200, description = "Project Access updated", body = ProjectAccessResponse),
+            (status = 400, description = "Invalid request", body = String),
+            (status = 404, description = "Project Access not found", body = String),
+            (status = 409, description = "Project Id, Service Account Id and Environment Id combination already exists", body = String),
+            (status = 500, description = "Internal server error", body = String),
+    ),
+)]
+pub async fn list(
+    service: web::Data<ProjectAccessService>,
+    filter: web::Query<ProjectAccessFilter>,
+    pagination: web::Query<Pagination>,
+) -> Result<HttpResponse, Error> {
+    let sort = vec![ProjectAccessSortOrder {
+        field: ProjectAccessSortableFields::Id,
+        order: SortOrder::Desc,
+    }];
+
+    let project_access = service
+        .find(
+            filter.into_inner(),
+            Some(sort),
+            Some(pagination.into_inner()),
+        )
+        .await
+        .map_err(actix_web::error::ErrorBadRequest)?;
+    Ok(HttpResponse::Ok().json(project_access))
+}
+
+pub fn configure_routes(config: &mut actix_web::web::ServiceConfig) {
+    config.service(
+        web::scope("/projects")
+            .service(
+                actix_web::web::resource("")
+                    .route(actix_web::web::post().to(post))
+                    .route(actix_web::web::get().to(list)),
+            )
+            .service(
+                actix_web::web::resource("/{id}")
+                    .route(actix_web::web::get().to(get))
+                    .route(actix_web::web::patch().to(patch))
+                    .route(actix_web::web::delete().to(delete)),
+            ),
+    );
+}

--- a/src/routes/project_access_route.rs
+++ b/src/routes/project_access_route.rs
@@ -127,7 +127,7 @@ pub async fn list(
 
 pub fn configure_routes(config: &mut actix_web::web::ServiceConfig) {
     config.service(
-        web::scope("/projects")
+        web::scope("/project-access")
             .service(
                 actix_web::web::resource("")
                     .route(actix_web::web::post().to(post))

--- a/src/routes/project_access_scopes_route.rs
+++ b/src/routes/project_access_scopes_route.rs
@@ -1,0 +1,183 @@
+use crate::models::pagination::Pagination;
+use crate::models::project_access_scopes::{
+    ProjectAccessScopeCreatePayload, ProjectAccessScopeFilter, ProjectAccessScopeResponse,
+    ProjectAccessScopeSortOrder, ProjectAccessScopeSortableFields, ProjectAccessScopeUpdatePayload,
+};
+use crate::models::sort::SortOrder;
+use crate::services::base::Service;
+use crate::services::project_access_scopes_service::ProjectAccessScopesService;
+use actix_web::{Error, HttpResponse, web};
+use uuid::Uuid;
+
+#[utoipa::path(
+    post,
+    path = "/project-access-scopes",
+    tag = "Project Access Scopes",
+    request_body = ProjectAccessScopeCreatePayload,
+    responses(
+        (status = 201, description = "Project access scope created", body = ProjectAccessScopeResponse),
+        (status = 400, description = "Invalid request", body = String),
+    ),
+)]
+pub async fn post(
+    service: web::Data<ProjectAccessScopesService>,
+    payload: web::Json<ProjectAccessScopeCreatePayload>,
+) -> Result<HttpResponse, Error> {
+    let project_access_scope = service
+        .create(payload.into_inner())
+        .await
+        .map_err(actix_web::error::ErrorBadRequest)?;
+    Ok(HttpResponse::Created().json(ProjectAccessScopeResponse::from(project_access_scope)))
+}
+
+#[utoipa::path(
+    get,
+    path = "/project-access-scopes/{id}",
+    tag = "Project Access Scopes",
+    responses(
+        (status = 200, description = "Project access scope found", body = ProjectAccessScopeResponse),
+        (status = 404, description = "Project access scope not found", body = String),
+    ),
+    params(
+        ("id" = String<uuid::Uuid>, Path, description = "Project Access Scope ID"),
+    ),
+)]
+pub async fn get(
+    service: web::Data<ProjectAccessScopesService>,
+    id: web::Path<Uuid>,
+) -> Result<HttpResponse, Error> {
+    let project_access_scope = service
+        .read(id.into_inner())
+        .await
+        .map_err(actix_web::error::ErrorNotFound)?;
+    match project_access_scope {
+        Some(scope) => Ok(HttpResponse::Ok().json(ProjectAccessScopeResponse::from(scope))),
+        None => Err(actix_web::error::ErrorNotFound(
+            "Project access scope not found",
+        )),
+    }
+}
+
+#[utoipa::path(
+    patch,
+    path = "/project-access-scopes/{id}",
+    tag = "Project Access Scopes",
+    request_body = ProjectAccessScopeUpdatePayload,
+    responses(
+        (status = 200, description = "Project access scope updated", body = ProjectAccessScopeResponse),
+        (status = 400, description = "Invalid request", body = String),
+        (status = 404, description = "Project access scope not found", body = String),
+        (status = 409, description = "Project access scope already exists", body = String),
+        (status = 500, description = "Internal server error", body = String),
+    ),
+    params(
+        ("id" = String<uuid::Uuid>, Path, description = "Project Access Scope ID"),
+    ),
+)]
+pub async fn patch(
+    service: web::Data<ProjectAccessScopesService>,
+    id: web::Path<Uuid>,
+    payload: web::Json<ProjectAccessScopeUpdatePayload>,
+) -> Result<HttpResponse, Error> {
+    let project_access_scope = service.update(id.into_inner(), payload.into_inner()).await;
+    if let Err(error) = project_access_scope {
+        let error_message = error.to_string();
+        match error_message.as_str() {
+            "No changes to update" => return Err(actix_web::error::ErrorBadRequest(error_message)),
+            "Project access scope not found" => {
+                return Err(actix_web::error::ErrorNotFound(error_message));
+            }
+            "Project access scope already exists" => {
+                return Err(actix_web::error::ErrorConflict(error_message));
+            }
+            _ => return Err(actix_web::error::ErrorInternalServerError(error_message)),
+        }
+    }
+    Ok(HttpResponse::Ok().json(ProjectAccessScopeResponse::from(
+        project_access_scope.unwrap(),
+    )))
+}
+
+#[utoipa::path(
+    delete,
+    path = "/project-access-scopes/{id}",
+    tag = "Project Access Scopes",
+    responses(
+        (status = 204, description = "Project access scope deleted", body = ()),
+        (status = 404, description = "Project access scope not found", body = String),
+    ),
+    params(
+        ("id" = String<uuid::Uuid>, Path, description = "Project Access Scope ID"),
+    )
+)]
+pub async fn delete(
+    service: web::Data<ProjectAccessScopesService>,
+    id: web::Path<Uuid>,
+) -> Result<HttpResponse, Error> {
+    let result = service.delete(id.into_inner()).await;
+    if let Err(error) = result {
+        let error_message = error.to_string();
+        match error_message.as_str() {
+            "Project access scope not found" => {
+                return Err(actix_web::error::ErrorNotFound(error_message));
+            }
+            _ => return Err(actix_web::error::ErrorInternalServerError(error_message)),
+        }
+    }
+    Ok(HttpResponse::NoContent().finish())
+}
+
+#[utoipa::path(
+    get,
+    path = "/project-access-scopes",
+    tag = "Project Access Scopes",
+    responses(
+        (status = 200, description = "Project access scopes found", body = Vec<ProjectAccessScopeResponse>),
+    ),
+    params(
+        ("project_access_id" = Option<String>, Query, description = "Filter by project access id"),
+        ("scope_id" = Option<String>, Query, description = "Filter by scope id"),
+        ("offset" = Option<u32>, Query, description = "Offset for pagination"),
+        ("limit" = Option<u32>, Query, description = "Number of items per page"),
+    )
+)]
+pub async fn list(
+    service: web::Data<ProjectAccessScopesService>,
+    filter: web::Query<ProjectAccessScopeFilter>,
+    pagination: web::Query<Pagination>,
+) -> Result<HttpResponse, Error> {
+    let sort = vec![ProjectAccessScopeSortOrder::new(
+        ProjectAccessScopeSortableFields::Id,
+        SortOrder::Asc,
+    )];
+    let project_access_scopes = service
+        .find(
+            filter.into_inner(),
+            Some(sort),
+            Some(pagination.into_inner()),
+        )
+        .await
+        .map_err(actix_web::error::ErrorInternalServerError)?;
+    let responses: Vec<ProjectAccessScopeResponse> = project_access_scopes
+        .into_iter()
+        .map(ProjectAccessScopeResponse::from)
+        .collect();
+    Ok(HttpResponse::Ok().json(responses))
+}
+
+pub fn configure_routes(config: &mut actix_web::web::ServiceConfig) {
+    config.service(
+        web::scope("/project-access-scopes")
+            .service(
+                actix_web::web::resource("")
+                    .route(actix_web::web::post().to(post))
+                    .route(actix_web::web::get().to(list)),
+            )
+            .service(
+                actix_web::web::resource("/{id}")
+                    .route(actix_web::web::get().to(get))
+                    .route(actix_web::web::patch().to(patch))
+                    .route(actix_web::web::delete().to(delete)),
+            ),
+    );
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,7 +1,7 @@
 pub mod base;
 pub mod environment_service;
+pub mod project_access_scopes_service;
+pub mod project_access_service;
 pub mod project_scope_service;
 pub mod project_service;
 pub mod service_account_service;
-pub mod project_access_service;
-pub mod project_access_scopes_service;

--- a/src/services/project_access_scopes_service.rs
+++ b/src/services/project_access_scopes_service.rs
@@ -36,7 +36,11 @@ impl Service<ProjectAccessScope> for ProjectAccessScopesService {
         self.repository.read(id).await
     }
 
-    async fn update(&self, id: Uuid, update: Self::UpdatePayload) -> Result<ProjectAccessScope, Error> {
+    async fn update(
+        &self,
+        id: Uuid,
+        update: Self::UpdatePayload,
+    ) -> Result<ProjectAccessScope, Error> {
         self.repository.update(id, update).await
     }
 

--- a/tests/integration/fixtures/project_access.sql
+++ b/tests/integration/fixtures/project_access.sql
@@ -1,3 +1,43 @@
+-- Projects
+INSERT INTO projects (id, name, description, created_at, updated_at, enabled) VALUES ('123e4567-e89b-12d3-a456-426614174000', 'testa', 'test', NOW(), NOW(), true);
+INSERT INTO projects (id, name, description, created_at, updated_at, enabled) VALUES ('123e4567-e89b-12d3-a456-426614174001', 'testb', 'test1', NOW(), NOW(), false);
+INSERT INTO projects (id, name, description, created_at, updated_at, enabled) VALUES ('123e4567-e89b-12d3-a456-426614173000', 'something', 'something', NOW(), NOW(), true);
+INSERT INTO projects (id, name, description, created_at, updated_at, enabled) VALUES ('123e4567-e89b-12d3-a456-426614173001', 'something1', 'something1', NOW(), NOW(), true);
+INSERT INTO projects (id, name, description, created_at, updated_at, enabled) VALUES ('123e4567-e89b-12d3-a456-426614179999', 'unique_project', 'unique for test', NOW(), NOW(), true);
+
+-- Service Accounts
+INSERT INTO service_account (id, name, email, secret, description, enabled, created_at, updated_at)
+VALUES 
+    ('123e4567-e89b-12d3-a456-426614174000', 'Test Account 1', 'test1@example.com', 'secret1', 'Test Description 1', true, NOW(), NOW()),
+    ('123e4567-e89b-12d3-a456-426614174001', 'Test Account 2', 'test2@example.com', 'secret2', 'Test Description 2', true, NOW(), NOW()),
+    ('123e4567-e89b-12d3-a456-426614174002', 'Test Account 3', 'test3@example.com', 'secret3', 'Test Description 3', false, NOW(), NOW()),
+    ('123e4567-e89b-12d3-a456-426614179998', 'Unique Account', 'unique@example.com', 'uniquesecret', 'Unique for test', true, NOW(), NOW());
+
+-- Environments for testa project (enabled project)
+INSERT INTO environment (id, project_id, name, description, enabled, created_at, updated_at) VALUES
+('00000000-0000-0000-0000-000000000001', '123e4567-e89b-12d3-a456-426614174000', 'dev', 'Development environment', true, NOW(), NOW()),
+('00000000-0000-0000-0000-000000000002', '123e4567-e89b-12d3-a456-426614174000', 'staging', 'Staging environment', false, NOW(), NOW()),
+('00000000-0000-0000-0000-000000000003', '123e4567-e89b-12d3-a456-426614174000', 'prod', 'Production environment', true, NOW(), NOW());
+
+-- Environments for testb project (disabled project)
+INSERT INTO environment (id, project_id, name, description, enabled, created_at, updated_at) VALUES
+('00000000-0000-0000-0000-000000000011', '123e4567-e89b-12d3-a456-426614174001', 'dev', 'Development environment', false, NOW(), NOW()),
+('00000000-0000-0000-0000-000000000012', '123e4567-e89b-12d3-a456-426614174001', 'prod', 'Production environment', true, NOW(), NOW());
+
+-- Environments for something project
+INSERT INTO environment (id, project_id, name, description, enabled, created_at, updated_at) VALUES
+('00000000-0000-0000-0000-000000000021', '123e4567-e89b-12d3-a456-426614173000', 'dev', 'Development environment', true, NOW(), NOW()),
+('00000000-0000-0000-0000-000000000022', '123e4567-e89b-12d3-a456-426614173000', 'prod', 'Production environment', false, NOW(), NOW());
+
+-- Environments for something1 project
+INSERT INTO environment (id, project_id, name, description, enabled, created_at, updated_at) VALUES
+('00000000-0000-0000-0000-000000000031', '123e4567-e89b-12d3-a456-426614173001', 'dev', 'Development environment', true, NOW(), NOW()),
+('00000000-0000-0000-0000-000000000032', '123e4567-e89b-12d3-a456-426614173001', 'staging', 'Staging environment', false, NOW(), NOW()),
+('00000000-0000-0000-0000-000000000033', '123e4567-e89b-12d3-a456-426614173001', 'prod', 'Production environment', true, NOW(), NOW());
+
+-- Environments for unique project
+INSERT INTO environment (id, project_id, name, description, enabled, created_at, updated_at) VALUES ('00000000-0000-0000-0000-000000009999', '123e4567-e89b-12d3-a456-426614179999', 'unique_env', 'Unique for test', true, NOW(), NOW());
+
 -- Project access for testa project, service account 1, dev environment
 INSERT INTO project_access (id, project_id, service_account_id, environment_id, enabled, created_at, updated_at) VALUES
 ('00000000-0000-0000-0000-000000000101', '123e4567-e89b-12d3-a456-426614174000', '123e4567-e89b-12d3-a456-426614174000', '00000000-0000-0000-0000-000000000001', true, NOW(), NOW()),

--- a/tests/integration/repositories/project_access_repository.rs
+++ b/tests/integration/repositories/project_access_repository.rs
@@ -12,31 +12,27 @@ use sentinel_guard::{
 use sqlx::PgPool;
 use uuid::Uuid;
 
-#[sqlx::test(fixtures(
-    "../fixtures/projects.sql",
-    "../fixtures/service_accounts.sql",
-    "../fixtures/environments.sql"
-))]
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
 async fn test_project_access_repository_create_with_valid_data_succeeds(pool: PgPool) {
     let repository = ProjectAccessRepository::new(Arc::new(pool));
     let payload = ProjectAccessCreatePayload {
-        project_id: "123e4567-e89b-12d3-a456-426614174000".to_string(),
-        service_account_id: "123e4567-e89b-12d3-a456-426614174000".to_string(),
-        environment_id: "00000000-0000-0000-0000-000000000001".to_string(),
+        project_id: "123e4567-e89b-12d3-a456-426614179999".to_string(),
+        service_account_id: "123e4567-e89b-12d3-a456-426614179998".to_string(),
+        environment_id: "00000000-0000-0000-0000-000000009999".to_string(),
         enabled: true,
     };
     let project_access = repository.create(payload.clone()).await.unwrap();
     assert_eq!(
         project_access.project_id,
-        Uuid::parse_str("123e4567-e89b-12d3-a456-426614174000").unwrap()
+        Uuid::parse_str("123e4567-e89b-12d3-a456-426614179999").unwrap()
     );
     assert_eq!(
         project_access.service_account_id,
-        Uuid::parse_str("123e4567-e89b-12d3-a456-426614174000").unwrap()
+        Uuid::parse_str("123e4567-e89b-12d3-a456-426614179998").unwrap()
     );
     assert_eq!(
         project_access.environment_id,
-        Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap()
+        Uuid::parse_str("00000000-0000-0000-0000-000000009999").unwrap()
     );
     assert!(project_access.enabled);
 }
@@ -56,12 +52,7 @@ async fn test_project_access_repository_create_with_missing_project_id_fails(poo
     assert_eq!(error_message, "Project not found");
 }
 
-#[sqlx::test(fixtures(
-    "../fixtures/projects.sql",
-    "../fixtures/service_accounts.sql",
-    "../fixtures/environments.sql",
-    "../fixtures/project_access.sql"
-))]
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
 async fn test_project_access_repository_create_with_duplicate_fails(pool: PgPool) {
     let repository = ProjectAccessRepository::new(Arc::new(pool));
     let payload = ProjectAccessCreatePayload {
@@ -79,12 +70,7 @@ async fn test_project_access_repository_create_with_duplicate_fails(pool: PgPool
     );
 }
 
-#[sqlx::test(fixtures(
-    "../fixtures/projects.sql",
-    "../fixtures/service_accounts.sql",
-    "../fixtures/environments.sql",
-    "../fixtures/project_access.sql"
-))]
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
 async fn test_project_access_repository_read_existing_succeeds(pool: PgPool) {
     let repository = ProjectAccessRepository::new(Arc::new(pool));
     let id = Uuid::parse_str("00000000-0000-0000-0000-000000000101").unwrap();
@@ -108,12 +94,7 @@ async fn test_project_access_repository_read_nonexistent_returns_error(pool: PgP
     assert_eq!(error_message, "Project access not found");
 }
 
-#[sqlx::test(fixtures(
-    "../fixtures/projects.sql",
-    "../fixtures/service_accounts.sql",
-    "../fixtures/environments.sql",
-    "../fixtures/project_access.sql"
-))]
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
 async fn test_project_access_repository_update_enabled_false_succeeds(pool: PgPool) {
     let repository = ProjectAccessRepository::new(Arc::new(pool));
     let id = Uuid::parse_str("00000000-0000-0000-0000-000000000101").unwrap();
@@ -124,12 +105,7 @@ async fn test_project_access_repository_update_enabled_false_succeeds(pool: PgPo
     assert!(!project_access.enabled);
 }
 
-#[sqlx::test(fixtures(
-    "../fixtures/projects.sql",
-    "../fixtures/service_accounts.sql",
-    "../fixtures/environments.sql",
-    "../fixtures/project_access.sql"
-))]
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
 async fn test_project_access_repository_update_enabled_true_succeeds(pool: PgPool) {
     let repository = ProjectAccessRepository::new(Arc::new(pool));
     let id = Uuid::parse_str("00000000-0000-0000-0000-000000000102").unwrap();
@@ -140,12 +116,7 @@ async fn test_project_access_repository_update_enabled_true_succeeds(pool: PgPoo
     assert!(project_access.enabled);
 }
 
-#[sqlx::test(fixtures(
-    "../fixtures/projects.sql",
-    "../fixtures/service_accounts.sql",
-    "../fixtures/environments.sql",
-    "../fixtures/project_access.sql"
-))]
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
 async fn test_project_access_delete_existing_succeeds(pool: PgPool) {
     let repository = ProjectAccessRepository::new(Arc::new(pool));
     let id = Uuid::parse_str("00000000-0000-0000-0000-000000000101").unwrap();
@@ -163,12 +134,7 @@ async fn test_project_access_delete_nonexisting_fails(pool: PgPool) {
     assert_eq!(error_message, "Project access not found");
 }
 
-#[sqlx::test(fixtures(
-    "../fixtures/projects.sql",
-    "../fixtures/service_accounts.sql",
-    "../fixtures/environments.sql",
-    "../fixtures/project_access.sql"
-))]
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
 async fn test_project_access_find_with_limit_pagination(pool: PgPool) {
     let repository = ProjectAccessRepository::new(Arc::new(pool));
     let filter = ProjectAccessFilter::default();
@@ -181,12 +147,7 @@ async fn test_project_access_find_with_limit_pagination(pool: PgPool) {
     assert_eq!(project_accesses.len(), 2);
 }
 
-#[sqlx::test(fixtures(
-    "../fixtures/projects.sql",
-    "../fixtures/service_accounts.sql",
-    "../fixtures/environments.sql",
-    "../fixtures/project_access.sql"
-))]
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
 async fn test_project_access_find_with_offset_pagination(pool: PgPool) {
     let repository = ProjectAccessRepository::new(Arc::new(pool));
     let filter = ProjectAccessFilter::default();
@@ -199,12 +160,7 @@ async fn test_project_access_find_with_offset_pagination(pool: PgPool) {
     assert_eq!(project_accesses.len(), 3);
 }
 
-#[sqlx::test(fixtures(
-    "../fixtures/projects.sql",
-    "../fixtures/service_accounts.sql",
-    "../fixtures/environments.sql",
-    "../fixtures/project_access.sql"
-))]
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
 async fn test_project_access_find_with_limit_offset_pagination(pool: PgPool) {
     let repository = ProjectAccessRepository::new(Arc::new(pool));
     let filter = ProjectAccessFilter::default();
@@ -217,12 +173,7 @@ async fn test_project_access_find_with_limit_offset_pagination(pool: PgPool) {
     assert_eq!(project_accesses.len(), 1);
 }
 
-#[sqlx::test(fixtures(
-    "../fixtures/projects.sql",
-    "../fixtures/service_accounts.sql",
-    "../fixtures/environments.sql",
-    "../fixtures/project_access.sql"
-))]
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
 async fn test_project_access_find_with_project_id_filter(pool: PgPool) {
     let repository = ProjectAccessRepository::new(Arc::new(pool));
     let filter = ProjectAccessFilter {
@@ -235,12 +186,7 @@ async fn test_project_access_find_with_project_id_filter(pool: PgPool) {
     assert_eq!(project_accesses.len(), 3);
 }
 
-#[sqlx::test(fixtures(
-    "../fixtures/projects.sql",
-    "../fixtures/service_accounts.sql",
-    "../fixtures/environments.sql",
-    "../fixtures/project_access.sql"
-))]
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
 async fn test_project_access_find_with_service_account_id_filter(pool: PgPool) {
     let repository = ProjectAccessRepository::new(Arc::new(pool));
     let filter = ProjectAccessFilter {
@@ -253,12 +199,7 @@ async fn test_project_access_find_with_service_account_id_filter(pool: PgPool) {
     assert_eq!(project_accesses.len(), 1);
 }
 
-#[sqlx::test(fixtures(
-    "../fixtures/projects.sql",
-    "../fixtures/service_accounts.sql",
-    "../fixtures/environments.sql",
-    "../fixtures/project_access.sql"
-))]
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
 async fn test_project_access_find_with_environment_id_filter(pool: PgPool) {
     let repository = ProjectAccessRepository::new(Arc::new(pool));
     let filter = ProjectAccessFilter {
@@ -271,12 +212,7 @@ async fn test_project_access_find_with_environment_id_filter(pool: PgPool) {
     assert_eq!(project_accesses.len(), 1);
 }
 
-#[sqlx::test(fixtures(
-    "../fixtures/projects.sql",
-    "../fixtures/service_accounts.sql",
-    "../fixtures/environments.sql",
-    "../fixtures/project_access.sql"
-))]
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
 async fn test_project_access_find_with_enabled_filter(pool: PgPool) {
     let repository = ProjectAccessRepository::new(Arc::new(pool));
     let filter = ProjectAccessFilter {

--- a/tests/integration/routes/mod.rs
+++ b/tests/integration/routes/mod.rs
@@ -1,5 +1,6 @@
 pub mod environment_route;
+pub mod project_access_route;
+pub mod project_access_scopes_route;
 pub mod project_route;
 pub mod project_scope_route;
 pub mod service_account_route;
-pub mod project_access_route;

--- a/tests/integration/routes/mod.rs
+++ b/tests/integration/routes/mod.rs
@@ -2,3 +2,4 @@ pub mod environment_route;
 pub mod project_route;
 pub mod project_scope_route;
 pub mod service_account_route;
+pub mod project_access_route;

--- a/tests/integration/routes/project_access_route.rs
+++ b/tests/integration/routes/project_access_route.rs
@@ -4,7 +4,7 @@ use sqlx::PgPool;
 
 use sentinel_guard::{
     models::project_access::{
-        ProjectAccessCreatePayload, ProjectAccessUpdatePayload, ProjectAccessResponse
+        ProjectAccessCreatePayload, ProjectAccessResponse, ProjectAccessUpdatePayload,
     },
     repositories::project_access_repository::ProjectAccessRepository,
     routes::project_access_route,
@@ -117,9 +117,7 @@ async fn test_project_access_route_patch_not_found(pool: PgPool) {
 #[sqlx::test(fixtures("../fixtures/project_access.sql"))]
 async fn test_project_access_route_patch_empty_payload(pool: PgPool) {
     let app = create_test_app!(services(pool), routes());
-    let payload = ProjectAccessUpdatePayload {
-        enabled: None,
-    };
+    let payload = ProjectAccessUpdatePayload { enabled: None };
     let response = actix_web::test::TestRequest::patch()
         .uri("/project-access/00000000-0000-0000-0000-000000000101")
         .set_json(&payload)
@@ -171,4 +169,4 @@ async fn test_project_access_route_list_filter_by_enabled(pool: PgPool) {
     let accesses: Vec<ProjectAccessResponse> = actix_web::test::read_body_json(response).await;
     assert!(!accesses.is_empty());
     assert!(accesses.iter().all(|a| !a.enabled));
-} 
+}

--- a/tests/integration/routes/project_access_route.rs
+++ b/tests/integration/routes/project_access_route.rs
@@ -1,0 +1,174 @@
+use std::sync::Arc;
+
+use sqlx::PgPool;
+
+use sentinel_guard::{
+    models::project_access::{
+        ProjectAccessCreatePayload, ProjectAccessUpdatePayload, ProjectAccessResponse
+    },
+    repositories::project_access_repository::ProjectAccessRepository,
+    routes::project_access_route,
+    services::project_access_service::ProjectAccessService,
+};
+
+fn services(pool: PgPool) -> ProjectAccessService {
+    ProjectAccessService::new(ProjectAccessRepository::new(Arc::new(pool)))
+}
+
+fn routes() -> fn(&mut actix_web::web::ServiceConfig) {
+    project_access_route::configure_routes
+}
+
+use crate::create_test_app;
+
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
+async fn test_project_access_route_create_valid(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+    let payload = ProjectAccessCreatePayload {
+        project_id: "123e4567-e89b-12d3-a456-426614174000".to_string(),
+        service_account_id: "123e4567-e89b-12d3-a456-426614174001".to_string(),
+        environment_id: "00000000-0000-0000-0000-000000000001".to_string(),
+        enabled: true,
+    };
+    let response = actix_web::test::TestRequest::post()
+        .uri("/project-access")
+        .set_json(&payload)
+        .send_request(&app)
+        .await;
+    assert_eq!(response.status(), actix_web::http::StatusCode::CREATED);
+    let created: ProjectAccessResponse = actix_web::test::read_body_json(response).await;
+    assert_eq!(created.project_id, payload.project_id);
+    assert_eq!(created.service_account_id, payload.service_account_id);
+    assert_eq!(created.environment_id, payload.environment_id);
+    assert!(created.enabled);
+}
+
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
+async fn test_project_access_route_create_duplicate_fails(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+    let payload = ProjectAccessCreatePayload {
+        project_id: "123e4567-e89b-12d3-a456-426614174000".to_string(),
+        service_account_id: "123e4567-e89b-12d3-a456-426614174000".to_string(),
+        environment_id: "00000000-0000-0000-0000-000000000001".to_string(),
+        enabled: true,
+    };
+    let response = actix_web::test::TestRequest::post()
+        .uri("/project-access")
+        .set_json(&payload)
+        .send_request(&app)
+        .await;
+
+    println!("response: {:?}", response);
+    assert_eq!(response.status(), actix_web::http::StatusCode::BAD_REQUEST);
+}
+
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
+async fn test_project_access_route_get_by_id_succeeds(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+    let response = actix_web::test::TestRequest::get()
+        .uri("/project-access/00000000-0000-0000-0000-000000000101")
+        .send_request(&app)
+        .await;
+    assert!(response.status().is_success());
+    let access: ProjectAccessResponse = actix_web::test::read_body_json(response).await;
+    assert_eq!(access.id, "00000000-0000-0000-0000-000000000101");
+}
+
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
+async fn test_project_access_route_get_by_id_not_found(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+    let response = actix_web::test::TestRequest::get()
+        .uri("/project-access/00000000-0000-0000-0000-00000000dead")
+        .send_request(&app)
+        .await;
+    assert!(response.status().is_client_error());
+}
+
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
+async fn test_project_access_route_patch_enabled_succeeds(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+    let payload = ProjectAccessUpdatePayload {
+        enabled: Some(false),
+    };
+    let response = actix_web::test::TestRequest::patch()
+        .uri("/project-access/00000000-0000-0000-0000-000000000101")
+        .set_json(&payload)
+        .send_request(&app)
+        .await;
+    assert!(response.status().is_success());
+    let updated: ProjectAccessResponse = actix_web::test::read_body_json(response).await;
+    assert!(!updated.enabled);
+}
+
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
+async fn test_project_access_route_patch_not_found(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+    let payload = ProjectAccessUpdatePayload {
+        enabled: Some(false),
+    };
+    let response = actix_web::test::TestRequest::patch()
+        .uri("/project-access/00000000-0000-0000-0000-00000000dead")
+        .set_json(&payload)
+        .send_request(&app)
+        .await;
+    assert!(response.status().is_client_error());
+}
+
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
+async fn test_project_access_route_patch_empty_payload(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+    let payload = ProjectAccessUpdatePayload {
+        enabled: None,
+    };
+    let response = actix_web::test::TestRequest::patch()
+        .uri("/project-access/00000000-0000-0000-0000-000000000101")
+        .set_json(&payload)
+        .send_request(&app)
+        .await;
+    assert!(response.status().is_client_error());
+}
+
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
+async fn test_project_access_route_delete_succeeds(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+    let response = actix_web::test::TestRequest::delete()
+        .uri("/project-access/00000000-0000-0000-0000-000000000101")
+        .send_request(&app)
+        .await;
+    assert!(response.status().is_success());
+}
+
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
+async fn test_project_access_route_delete_not_found(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+    let response = actix_web::test::TestRequest::delete()
+        .uri("/project-access/00000000-0000-0000-0000-00000000dead")
+        .send_request(&app)
+        .await;
+    assert!(response.status().is_client_error());
+}
+
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
+async fn test_project_access_route_list_all(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+    let response = actix_web::test::TestRequest::get()
+        .uri("/project-access")
+        .send_request(&app)
+        .await;
+    assert!(response.status().is_success());
+    let accesses: Vec<ProjectAccessResponse> = actix_web::test::read_body_json(response).await;
+    assert!(!accesses.is_empty());
+}
+
+#[sqlx::test(fixtures("../fixtures/project_access.sql"))]
+async fn test_project_access_route_list_filter_by_enabled(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+    let response = actix_web::test::TestRequest::get()
+        .uri("/project-access?enabled=false")
+        .send_request(&app)
+        .await;
+    assert!(response.status().is_success());
+    let accesses: Vec<ProjectAccessResponse> = actix_web::test::read_body_json(response).await;
+    assert!(!accesses.is_empty());
+    assert!(accesses.iter().all(|a| !a.enabled));
+} 

--- a/tests/integration/routes/project_access_scopes_route.rs
+++ b/tests/integration/routes/project_access_scopes_route.rs
@@ -1,0 +1,170 @@
+use std::sync::Arc;
+
+use sqlx::PgPool;
+
+use sentinel_guard::{
+    models::project_access_scopes::{
+        ProjectAccessScopeCreatePayload, ProjectAccessScopeResponse,
+        ProjectAccessScopeUpdatePayload,
+    },
+    repositories::project_access_scopes_repository::ProjectAccessScopesRepository,
+    routes::project_access_scopes_route,
+    services::project_access_scopes_service::ProjectAccessScopesService,
+};
+
+fn services(pool: PgPool) -> ProjectAccessScopesService {
+    ProjectAccessScopesService::new(ProjectAccessScopesRepository::new(Arc::new(pool)))
+}
+
+fn routes() -> fn(&mut actix_web::web::ServiceConfig) {
+    project_access_scopes_route::configure_routes
+}
+
+use crate::create_test_app;
+
+#[sqlx::test(fixtures("../fixtures/project_access_scopes.sql"))]
+async fn test_project_access_scopes_route_create_valid(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+    let payload = ProjectAccessScopeCreatePayload {
+        project_access_id: "00000000-0000-0000-0000-000000000102".to_string(),
+        scope_id: "00000000-0000-0000-0000-000000000002".to_string(),
+    };
+    let response = actix_web::test::TestRequest::post()
+        .uri("/project-access-scopes")
+        .set_json(&payload)
+        .send_request(&app)
+        .await;
+    assert_eq!(response.status(), actix_web::http::StatusCode::CREATED);
+    let created: ProjectAccessScopeResponse = actix_web::test::read_body_json(response).await;
+    assert_eq!(created.project_access_id, payload.project_access_id);
+    assert_eq!(created.scope_id, payload.scope_id);
+    assert!(created.enabled);
+}
+
+#[sqlx::test(fixtures("../fixtures/project_access_scopes.sql"))]
+async fn test_project_access_scopes_route_create_duplicate_fails(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+    let payload = ProjectAccessScopeCreatePayload {
+        project_access_id: "00000000-0000-0000-0000-000000000101".to_string(),
+        scope_id: "00000000-0000-0000-0000-000000000001".to_string(),
+    };
+    let response = actix_web::test::TestRequest::post()
+        .uri("/project-access-scopes")
+        .set_json(&payload)
+        .send_request(&app)
+        .await;
+    assert_eq!(response.status(), actix_web::http::StatusCode::BAD_REQUEST);
+}
+
+#[sqlx::test(fixtures("../fixtures/project_access_scopes.sql"))]
+async fn test_project_access_scopes_route_get_by_id_succeeds(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+    let response = actix_web::test::TestRequest::get()
+        .uri("/project-access-scopes/00000000-0000-0000-0000-000000001001")
+        .send_request(&app)
+        .await;
+    assert!(response.status().is_success());
+    let scope: ProjectAccessScopeResponse = actix_web::test::read_body_json(response).await;
+    assert_eq!(scope.id, "00000000-0000-0000-0000-000000001001");
+}
+
+#[sqlx::test(fixtures("../fixtures/project_access_scopes.sql"))]
+async fn test_project_access_scopes_route_get_by_id_not_found(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+    let response = actix_web::test::TestRequest::get()
+        .uri("/project-access-scopes/00000000-0000-0000-0000-00000000dead")
+        .send_request(&app)
+        .await;
+    assert!(response.status().is_client_error());
+}
+
+#[sqlx::test(fixtures("../fixtures/project_access_scopes.sql"))]
+async fn test_project_access_scopes_route_patch_enabled_succeeds(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+    let payload = ProjectAccessScopeUpdatePayload {
+        enabled: Some(false),
+    };
+    let response = actix_web::test::TestRequest::patch()
+        .uri("/project-access-scopes/00000000-0000-0000-0000-000000001001")
+        .set_json(&payload)
+        .send_request(&app)
+        .await;
+    assert!(response.status().is_success());
+    let updated: ProjectAccessScopeResponse = actix_web::test::read_body_json(response).await;
+    assert!(!updated.enabled);
+}
+
+#[sqlx::test(fixtures("../fixtures/project_access_scopes.sql"))]
+async fn test_project_access_scopes_route_patch_not_found(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+    let payload = ProjectAccessScopeUpdatePayload {
+        enabled: Some(false),
+    };
+    let response = actix_web::test::TestRequest::patch()
+        .uri("/project-access-scopes/00000000-0000-0000-0000-00000000dead")
+        .set_json(&payload)
+        .send_request(&app)
+        .await;
+    assert!(response.status().is_client_error());
+}
+
+#[sqlx::test(fixtures("../fixtures/project_access_scopes.sql"))]
+async fn test_project_access_scopes_route_patch_empty_payload(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+    let payload = ProjectAccessScopeUpdatePayload { enabled: None };
+    let response = actix_web::test::TestRequest::patch()
+        .uri("/project-access-scopes/00000000-0000-0000-0000-000000001001")
+        .set_json(&payload)
+        .send_request(&app)
+        .await;
+    assert!(response.status().is_client_error());
+}
+
+#[sqlx::test(fixtures("../fixtures/project_access_scopes.sql"))]
+async fn test_project_access_scopes_route_delete_succeeds(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+    let response = actix_web::test::TestRequest::delete()
+        .uri("/project-access-scopes/00000000-0000-0000-0000-000000001001")
+        .send_request(&app)
+        .await;
+    assert!(response.status().is_success());
+}
+
+#[sqlx::test(fixtures("../fixtures/project_access_scopes.sql"))]
+async fn test_project_access_scopes_route_delete_not_found(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+    let response = actix_web::test::TestRequest::delete()
+        .uri("/project-access-scopes/00000000-0000-0000-0000-00000000dead")
+        .send_request(&app)
+        .await;
+    assert!(response.status().is_client_error());
+}
+
+#[sqlx::test(fixtures("../fixtures/project_access_scopes.sql"))]
+async fn test_project_access_scopes_route_list_all(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+    let response = actix_web::test::TestRequest::get()
+        .uri("/project-access-scopes")
+        .send_request(&app)
+        .await;
+    assert!(response.status().is_success());
+    let scopes: Vec<ProjectAccessScopeResponse> = actix_web::test::read_body_json(response).await;
+    assert!(!scopes.is_empty());
+}
+
+#[sqlx::test(fixtures("../fixtures/project_access_scopes.sql"))]
+async fn test_project_access_scopes_route_list_filter_by_project_access_id(pool: PgPool) {
+    let app = create_test_app!(services(pool), routes());
+    let response = actix_web::test::TestRequest::get()
+        .uri("/project-access-scopes?project_access_id=00000000-0000-0000-0000-000000000101")
+        .send_request(&app)
+        .await;
+    assert!(response.status().is_success());
+    let scopes: Vec<ProjectAccessScopeResponse> = actix_web::test::read_body_json(response).await;
+    assert!(!scopes.is_empty());
+    assert!(
+        scopes
+            .iter()
+            .all(|s| s.project_access_id == "00000000-0000-0000-0000-000000000101")
+    );
+}


### PR DESCRIPTION
This PR introduces routes and integration tests for Project Access and Project Access Scopes management:

- **Project Access Routes**:
  - Created `project_access_route` module with CRUD endpoints
  - Endpoints for:
    - Creating project access entries
    - Retrieving project access details
    - Updating project access
    - Deleting project access entries
  - Changed route scope from `/projects` to `/project-access`
  - Comprehensive integration tests covering:
    - Create operations
    - Read operations
    - Update operations
    - Delete operations
    - Error handling scenarios

- **Project Access Scopes Routes**:
  - Implemented `project_access_scopes_route` module
  - CRUD endpoints for managing project access scopes
  - Integration tests ensuring:
    - Correct creation of access scopes
    - Retrieving access scope details
    - Updating access scopes
    - Deleting access scopes
    - Proper error handling

- **Main Application Configuration**:
  - Registered new routes for project access and project access scopes
  - Updated route configuration in main function
  - Improved service initialization formatting

- **Test Fixtures**:
  - Enhanced `project_access.sql` with additional test data
  - Expanded test coverage for repository and route operations

- **Code Quality Improvements**:
  - Reorganized service module imports
  - Improved method formatting
  - Aligned parameters across multiple lines for better readability

This implementation provides a complete solution for managing project access and access scopes, with robust routes, services, and comprehensive test coverage.

Resolve #21 